### PR TITLE
chore: use-sound を v5 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "react-dom": "^18.2.0",
                 "react-i18next": "^13.0.2",
                 "typescript": "^5.1.6",
-                "use-sound": "^4.0.1",
+                "use-sound": "^5.0.0",
                 "use-timer": "^2.0.1"
             },
             "devDependencies": {
@@ -5786,9 +5786,9 @@
             }
         },
         "node_modules/use-sound": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/use-sound/-/use-sound-4.0.4.tgz",
-            "integrity": "sha512-SW81yRUu3K0rJHW0WVANCAK581A2qgD97+QrLxPhlAhvdIAIgw2J9d1VThdbHmPHjzCbwKE/is82V88sgFdjCg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/use-sound/-/use-sound-5.0.0.tgz",
+            "integrity": "sha512-MNHT3FFC5HxNCrgZtrnpIMJI2cw/0D2xismcrtyht8BTuF5FhFhb57xO/jlQr2xJaFrc/0btzRQvGyHQwB7PVA==",
             "license": "MIT",
             "dependencies": {
                 "howler": "^2.2.4"

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
         "@types/node": "^20.4.2",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
+        "i18next": "^23.2.11",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-i18next": "^13.0.2",
         "typescript": "^5.1.6",
-        "use-sound": "^4.0.1",
-        "use-timer": "^2.0.1",
-        "i18next": "^23.2.11",
-        "react-i18next": "^13.0.2"
+        "use-sound": "^5.0.0",
+        "use-timer": "^2.0.1"
     },
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## 概要
- `use-sound` を `^4.0.1` から `^5.0.0` に更新しました。
- メジャー更新のため、依存1件のみを対象にしたPRです。

## 変更理由
- semver範囲外（メジャー）更新を保守対象に含めるため。

## 事前調査（変更ログ / Breaking Changes）
- `use-sound` のリリースノートを確認しました。
- v5.0.0: スプライト利用時の `playbackRate` まわりの不具合修正が中心。
- 破壊的変更として明記されているのは v4.0.0（`isPlaying` の削除）で、今回の v4系→v5.0.0 では追加のBreaking Changesは確認できませんでした。

## 検証
- `npm test` ✅
- `npm run build` ✅

## 補足
- 他のメジャー更新候補（React / i18next系など）はこのPRには含めていません（1依存1PRルールに従うため）。