### PR TITLE
chore: i18next を v26 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@types/node": "^20.4.2",
                 "@types/react": "^18.2.15",
                 "@types/react-dom": "^18.2.7",
-                "i18next": "^23.2.11",
+                "i18next": "^26.0.1",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-i18next": "^13.0.2",
@@ -285,9 +285,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-            "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -3563,26 +3563,34 @@
             }
         },
         "node_modules/i18next": {
-            "version": "23.16.8",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
-            "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+            "version": "26.0.1",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.1.tgz",
+            "integrity": "sha512-vtz5sXU4+nkCm8yEU+JJ6yYIx0mkg9e68W0G0PXpnOsmzLajNsW5o28DJMqbajxfsfq0gV3XdrBudsDQnwxfsQ==",
             "funding": [
                 {
                     "type": "individual",
-                    "url": "https://locize.com"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://locize.com/i18next.html"
+                    "url": "https://www.locize.com/i18next"
                 },
                 {
                     "type": "individual",
                     "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.locize.com"
                 }
             ],
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.23.2"
+                "@babel/runtime": "^7.29.2"
+            },
+            "peerDependencies": {
+                "typescript": "^5 || ^6"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "@types/node": "^20.4.2",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
-        "i18next": "^23.2.11",
+        "i18next": "^26.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^13.0.2",


### PR DESCRIPTION
## 概要
- `i18next` を `^23.2.11` から `^26.0.1` に更新しました。
- メジャー更新のため、依存1件のみを対象にしたPRです。

## 事前調査（変更ログ / Breaking Changes）
- i18next v26.0.0 のリリースノートで Breaking Changes を確認。
  - `initImmediate` の廃止
  - 旧 `interpolation.format` 関数の廃止
  - `showSupportNotice` / `simplifyPluralSuffix` の廃止 など
- 本リポジトリ内で上記オプションの利用を検索し、該当なしを確認しました。

## 検証
- `npm test` ✅
- `npm run build` ✅

## 補足
- ほかのメジャー更新候補（React / react-i18next など）は、1依存1PRルールに従い本PRには含めていません。