### PR TITLE
GitHub Actionsにsafe-chain導入を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
           node-version: 20
           cache: npm
 
+      - name: Install safe-chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -31,8 +31,12 @@ jobs:
         with:
           node-version: 20
           cache: npm
+      - name: Install safe-chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+      - name: Install dependencies
+        run: npm ci
       - name: build
-        run: npm ci && npm run build
+        run: npm run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## 概要
- `.github/workflows/ci.yml` に safe-chain のインストール手順を追加
- `.github/workflows/gh_pages.yml` に safe-chain のインストール手順を追加
- `npm ci && npm run build` を `npm ci` と `npm run build` に分割し、safe-chain を `npm ci` の前に実行

## 変更範囲
- GitHub Actions ワークフローのみ（依存関係やライブラリのバージョン変更なし）

## 確認観点
- 各ワークフローで safe-chain が `npm ci` より前に実行されること
