### PR TITLE
chore: @types/node を 20.19.37 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
             "name": "iroawase",
             "version": "1.0.0",
             "dependencies": {
-                "@types/node": "^20.4.2",
                 "@types/react": "^18.2.15",
                 "@types/react-dom": "^18.2.7",
                 "i18next": "^26.0.1",
@@ -20,6 +19,7 @@
                 "use-timer": "^2.0.1"
             },
             "devDependencies": {
+                "@types/node": "^20.19.37",
                 "@typescript-eslint/eslint-plugin": "^6.0.0",
                 "@typescript-eslint/parser": "^6.0.0",
                 "@vitejs/plugin-react": "^4.0.3",
@@ -1432,9 +1432,10 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "20.19.35",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
-            "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+            "version": "20.19.37",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+            "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
@@ -5750,6 +5751,7 @@
             "version": "6.21.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
             "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "version": "1.0.0",
     "homepage": "./",
     "dependencies": {
-        "@types/node": "^20.4.2",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
         "i18next": "^26.0.1",
@@ -27,6 +26,7 @@
         ]
     },
     "devDependencies": {
+        "@types/node": "^20.19.37",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "@vitejs/plugin-react": "^4.0.3",


### PR DESCRIPTION
## 概要
- `@types/node` を `20.19.35` から `20.19.37` へ更新しました。

## 変更内容
- `package.json` の `devDependencies` を更新
- `package-lock.json` を更新

## 検証
- `npm test` 実行: 成功
- `npm run build` 実行: 成功

## メジャー更新の検証状況（別件）
- semver範囲外の更新候補として `vite` 4 -> 8 を事前検証しました。
- Vite 8 の Breaking Changes（公式 changelog / migration guide）を確認したうえで試行しましたが、`npm test` 時に ESM 読み込みエラーで失敗したため、今回は見送りました。