### PR TITLE
chore: @types/node を v25 系へ更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "use-timer": "^2.0.1"
             },
             "devDependencies": {
-                "@types/node": "^20.19.37",
+                "@types/node": "^25.5.2",
                 "@typescript-eslint/eslint-plugin": "^6.0.0",
                 "@typescript-eslint/parser": "^6.0.0",
                 "@vitejs/plugin-react": "^4.0.3",
@@ -1432,13 +1432,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "20.19.37",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-            "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+            "version": "25.5.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+            "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.21.0"
+                "undici-types": "~7.18.0"
             }
         },
         "node_modules/@types/prop-types": {
@@ -5748,9 +5748,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "version": "7.18.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         ]
     },
     "devDependencies": {
-        "@types/node": "^20.19.37",
+        "@types/node": "^25.5.2",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "@vitejs/plugin-react": "^4.0.3",


### PR DESCRIPTION
## 概要
- `@types/node` を `20.19.37` から `25.5.2` へメジャー更新しました。
- semver範囲外（major）更新のため、1依存関係のみをこのPRで更新しています。

## 変更内容
- `package.json` の `@types/node` を `^25.5.2` へ更新
- `package-lock.json` を更新

## 変更ログ / Breaking Changes の確認
Node.js v25.0.0 のリリースノートを確認し、複数の SemVer Major 変更（非推奨APIのEOL移行や削除）があることを確認しました。
本リポジトリはブラウザ向けアプリで、Node実行時APIへの依存はビルドツール中心のため、影響は型定義まわりに限定される想定です。

## 検証
- `npm test` ✅
- `npm run build` ✅

CI（PRの `ci.yml`）成功を確認後にマージします。