### PR TITLE
依存更新: react-i18next を v17 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "i18next": "^26.0.1",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
-                "react-i18next": "^13.0.2",
+                "react-i18next": "^17.0.2",
                 "typescript": "^5.1.6",
                 "use-sound": "^5.0.0",
                 "use-timer": "^2.0.1"
@@ -4877,23 +4877,28 @@
             }
         },
         "node_modules/react-i18next": {
-            "version": "13.5.0",
-            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-13.5.0.tgz",
-            "integrity": "sha512-CFJ5NDGJ2MUyBohEHxljOq/39NQ972rh1ajnadG9BjTk+UXbHLq4z5DKEbEQBDoIhUmmbuS/fIMJKo6VOax1HA==",
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.2.tgz",
+            "integrity": "sha512-shBftH2vaTWK2Bsp7FiL+cevx3xFJlvFxmsDFQSrJc+6twHkP0tv/bGa01VVWzpreUVVwU+3Hev5iFqRg65RwA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.22.5",
-                "html-parse-stringify": "^3.0.1"
+                "@babel/runtime": "^7.29.2",
+                "html-parse-stringify": "^3.0.1",
+                "use-sync-external-store": "^1.6.0"
             },
             "peerDependencies": {
-                "i18next": ">= 23.2.3",
-                "react": ">= 16.8.0"
+                "i18next": ">= 26.0.1",
+                "react": ">= 16.8.0",
+                "typescript": "^5 || ^6"
             },
             "peerDependenciesMeta": {
                 "react-dom": {
                     "optional": true
                 },
                 "react-native": {
+                    "optional": true
+                },
+                "typescript": {
                     "optional": true
                 }
             }
@@ -5805,6 +5810,15 @@
             },
             "peerDependencies": {
                 "react": ">=16.8"
+            }
+        },
+        "node_modules/use-sync-external-store": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/use-timer": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "i18next": "^26.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-i18next": "^13.0.2",
+        "react-i18next": "^17.0.2",
         "typescript": "^5.1.6",
         "use-sound": "^5.0.0",
         "use-timer": "^2.0.1"


### PR DESCRIPTION
## 概要
- `react-i18next` を `^13.0.2` から `^17.0.2` へメジャー更新しました。
- メジャー更新のため、このPRでは `react-i18next` のみを更新しています。

## 変更内容
- `package.json` の `react-i18next` を更新
- `package-lock.json` を更新

## 変更ログ / Breaking Changes の確認
- CHANGELOG: https://raw.githubusercontent.com/i18next/react-i18next/master/CHANGELOG.md
- v17.0.0 の Potentially breaking changes
  - `Trans` コンポーネントで、補間や mixed content を含む子要素の HTML タグ名保持挙動が修正されました
  - 明示的な `i18nKey` を使わず、auto-generated key に依存している場合は翻訳キーの見直しが必要になる可能性があります
- 追加確認
  - v17.0.1 で peer dependency が `i18next >= 26.0.1` に更新されています
  - このリポジトリでは `react-i18next` / `useTranslation` / `Trans` の利用がなく、上記変更の影響が出ないことを確認しました

## 検証
- `npm test` ✅
- `npm run build` ✅
- GitHub Actions `CI` 成功確認後にマージ予定です
