### PR TITLE
i18next を 26.0.5 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@types/react": "^18.2.15",
                 "@types/react-dom": "^18.2.7",
-                "i18next": "^26.0.1",
+                "i18next": "^26.0.5",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-i18next": "^17.0.2",
@@ -3564,9 +3564,9 @@
             }
         },
         "node_modules/i18next": {
-            "version": "26.0.1",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.1.tgz",
-            "integrity": "sha512-vtz5sXU4+nkCm8yEU+JJ6yYIx0mkg9e68W0G0PXpnOsmzLajNsW5o28DJMqbajxfsfq0gV3XdrBudsDQnwxfsQ==",
+            "version": "26.0.5",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.5.tgz",
+            "integrity": "sha512-9uHb4T27TdV36phJXcbpnRPt5yzAfqHXVrdASvmHZyPuZJtrLythd+GyXhiaHV5LlpuuskbAqhwPjmfTbKbi8w==",
             "funding": [
                 {
                     "type": "individual",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dependencies": {
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
-        "i18next": "^26.0.1",
+        "i18next": "^26.0.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^17.0.2",


### PR DESCRIPTION
## 概要
- `i18next` を `26.0.1` から `26.0.5` に更新
- lockfile を更新

## 確認
- `npm test`
- `npm run build`

## メモ
- メジャー更新候補の `react` 19 系と `typescript` 6 系は、公開アップグレードガイドの破壊的変更を確認し、今回は見送り
