### PR TITLE
@types/node を 25.6.0 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "use-timer": "^2.0.1"
             },
             "devDependencies": {
-                "@types/node": "^25.5.2",
+                "@types/node": "^25.6.0",
                 "@typescript-eslint/eslint-plugin": "^6.0.0",
                 "@typescript-eslint/parser": "^6.0.0",
                 "@vitejs/plugin-react": "^4.0.3",
@@ -1432,13 +1432,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.5.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-            "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+            "version": "25.6.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+            "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.18.0"
+                "undici-types": "~7.19.0"
             }
         },
         "node_modules/@types/prop-types": {
@@ -5753,9 +5753,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.18.2",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+            "version": "7.19.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+            "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         ]
     },
     "devDependencies": {
-        "@types/node": "^25.5.2",
+        "@types/node": "^25.6.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "@vitejs/plugin-react": "^4.0.3",


### PR DESCRIPTION
## 概要
- `@types/node` を `25.5.2` から `25.6.0` に更新
- lockfile を更新

## 確認
- `npm test`
- `npm run build`

## 見送りメモ
- `i18next@26.0.5`: safe-chain の minimum package age で PR CI が失敗
- `typescript@6.0.2`: `moduleResolution=node10` の非推奨エラーでビルド失敗
