### PR TITLE
TypeScript を v6 に更新

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,2 @@
 declare module '*.png';
+declare module '*.css';

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-i18next": "^17.0.2",
-                "typescript": "^5.1.6",
+                "typescript": "^6.0.3",
                 "use-sound": "^5.0.0",
                 "use-timer": "^2.0.1"
             },
@@ -5714,9 +5714,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^17.0.2",
-        "typescript": "^5.1.6",
+        "typescript": "^6.0.3",
         "use-sound": "^5.0.0",
         "use-timer": "^2.0.1"
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
         "forceConsistentCasingInFileNames": true,
         "noFallthroughCasesInSwitch": true,
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "resolveJsonModule": true,
         "isolatedModules": true,
         "noEmit": true,


### PR DESCRIPTION
## 概要
- `typescript` を `^5.1.6` から `^6.0.3` へ更新しました
- TypeScript 6 の変更に合わせて `moduleResolution` を `node` から `bundler` に更新しました
- TypeScript 6 で表面化した CSS の side-effect import エラーに対応するため、`*.css` の型宣言を追加しました

## 変更ログ / breaking changes の確認
- TypeScript 6.0 のリリースノートを確認しました
- このリポジトリに関係した主な変更は、`moduleResolution: "node"` が非推奨扱いになった点です
- Vite ベースのフロントエンドなので、推奨に沿って `moduleResolution: "bundler"` へ移行しました
- 更新後にビルドで CSS の side-effect import エラーが出たため、`index.d.ts` に `declare module '*.css';` を追加して解消しました

## 確認したこと
- `npm test`
- `npm run build`
- GitHub Project: https://github.com/users/kurehajime/projects/2/
