### PR TITLE
chore: i18next を 26.0.8 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@types/react": "^18.2.15",
                 "@types/react-dom": "^18.2.7",
-                "i18next": "^26.0.1",
+                "i18next": "^26.0.8",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-i18next": "^17.0.2",
@@ -3564,9 +3564,9 @@
             }
         },
         "node_modules/i18next": {
-            "version": "26.0.1",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.1.tgz",
-            "integrity": "sha512-vtz5sXU4+nkCm8yEU+JJ6yYIx0mkg9e68W0G0PXpnOsmzLajNsW5o28DJMqbajxfsfq0gV3XdrBudsDQnwxfsQ==",
+            "version": "26.0.8",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.8.tgz",
+            "integrity": "sha512-BRzLom0mhDhV9v0QhgUUHWQJuwFmnr1194xEcNLYD6ym8y8s542n4jXUvRLnhNTbh9PmpU6kGZamyuGHQMsGjw==",
             "funding": [
                 {
                     "type": "individual",
@@ -3582,9 +3582,6 @@
                 }
             ],
             "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.29.2"
-            },
             "peerDependencies": {
                 "typescript": "^5 || ^6"
             },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dependencies": {
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
-        "i18next": "^26.0.1",
+        "i18next": "^26.0.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^17.0.2",


### PR DESCRIPTION
## 概要
- `i18next` を `^26.0.1` から `^26.0.8` に更新しました
- `package-lock.json` を更新しました

## 変更内容
- `package.json` の `i18next` を更新
- `package-lock.json` を更新

## 変更ログ確認
- Releases: https://github.com/i18next/i18next/releases
- 今回取り込まれる主な差分
  - 2026-04-18 の security release を含みます
  - `@babel/runtime` への runtime 依存削除
  - 型定義まわりの不具合修正

## 検証
- `npm test` ✅
- `npm run build` ✅

## 補足
- 2026-04-16 に safe-chain の minimum package age で一度見送った更新を、期間経過後に再試行しています
- PR の CI 成功後にマージし、マージ後の main CI / Pages も確認します
