### PR TITLE
chore: react-i18next を 17.0.4 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "i18next": "^26.0.1",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
-                "react-i18next": "^17.0.2",
+                "react-i18next": "^17.0.4",
                 "typescript": "^6.0.3",
                 "use-sound": "^5.0.0",
                 "use-timer": "^2.0.1"
@@ -4877,9 +4877,9 @@
             }
         },
         "node_modules/react-i18next": {
-            "version": "17.0.2",
-            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.2.tgz",
-            "integrity": "sha512-shBftH2vaTWK2Bsp7FiL+cevx3xFJlvFxmsDFQSrJc+6twHkP0tv/bGa01VVWzpreUVVwU+3Hev5iFqRg65RwA==",
+            "version": "17.0.4",
+            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.4.tgz",
+            "integrity": "sha512-hQipmK4EF0y6RO6tt6WuqnmWpWYEXmQUUzecmMBuNsIgYd3smXcG4GtYPWhvgxn0pqMOItKlEO8H24HCs5hc3g==",
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.29.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "i18next": "^26.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-i18next": "^17.0.2",
+        "react-i18next": "^17.0.4",
         "typescript": "^6.0.3",
         "use-sound": "^5.0.0",
         "use-timer": "^2.0.1"


### PR DESCRIPTION
## 概要
- `react-i18next` を `^17.0.2` から `^17.0.4` に更新しました
- `package-lock.json` を更新しました

## 変更内容
- `package.json` の `react-i18next` を更新
- `package-lock.json` を更新

## 変更ログ確認
- CHANGELOG: https://github.com/i18next/react-i18next/blob/master/CHANGELOG.md
- 今回取り込まれる主な差分
  - `TransWithoutContext` の型修正
  - `defaultVariables` の補間挙動修正
  - `Trans` 周辺の不具合修正

## 検証
- `npm test` ✅
- `npm run build` ✅

## 補足
- 同じリポジトリの `i18next 26.0.8` 更新は safe-chain の minimum package age で CI 失敗したため今回は見送りました
- PR の CI 成功後にマージし、マージ後の main CI / Pages も確認します
