### PR TITLE
chore: GitHub Actions を Node 24 系ランタイムへ更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -38,9 +38,9 @@ jobs:
       - name: build
         run: npm run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './docs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## 概要
- CI / GitHub Pages workflow で使っている GitHub Actions を Node 24 系ランタイムの版へ更新
- `actions/checkout` を `v4` から `v5` へ更新
- `actions/configure-pages` を `v5` から `v6` へ更新
- `actions/setup-node` を `v4` から `v5` へ更新（Pages / CI 両方）
- `actions/upload-pages-artifact` を `v3` から `v5` へ更新
- `actions/deploy-pages` を `v4` から `v5` へ更新

## 確認
- `npm test`
- `npm run build`
