### PR TITLE
chore: vite-plugin-singlefile を 2.3.3 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint": "^8.45.0",
         "eslint-plugin-react": "^7.32.2",
         "vite": "^8.0.10",
-        "vite-plugin-singlefile": "^0.13.5",
+        "vite-plugin-singlefile": "^2.3.3",
         "vitest": "^4.1.5"
       }
     },
@@ -4574,6 +4574,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -5447,20 +5448,25 @@
       }
     },
     "node_modules/vite-plugin-singlefile": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-0.13.5.tgz",
-      "integrity": "sha512-y/aRGh8qHmw2f1IhaI/C6PJAaov47ESYDvUv1am1YHMhpY+19B5k5Odp8P+tgs+zhfvak6QB1ykrALQErEAo7g==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-2.3.3.tgz",
+      "integrity": "sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "micromatch": "^4.0.5"
+        "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": ">18.0.0"
       },
       "peerDependencies": {
-        "rollup": ">=2.79.0",
-        "vite": ">=3.2.0"
+        "rollup": "^4.59.0",
+        "vite": "^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite/node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint": "^8.45.0",
     "eslint-plugin-react": "^7.32.2",
     "vite": "^8.0.10",
-    "vite-plugin-singlefile": "^0.13.5",
+    "vite-plugin-singlefile": "^2.3.3",
     "vitest": "^4.1.5"
   }
 }


### PR DESCRIPTION
## 概要
- `vite-plugin-singlefile` を `^0.13.5` から `^2.3.3` に更新
- changelog を確認し、0.8.0 / 1.0.0 / 2.0.0 の breaking change を把握したうえで適用

## 確認した breaking change
- 0.8.0: `type: module` 前提の注意あり
- 1.0.0: Node 18 / Vite 5 以上が必要
- 2.0.0: Vite 5.1 以上が必要
- 2.3.1: Vite 8 対応

このリポジトリは CI が Node 20、依存は Vite 8 系なので要件に合っていることを確認した。

## 検証
- `npm test`
- `npm run build`
