### PR TITLE
chore: react-i18next を v17 系へ更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "i18next": "^26.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-i18next": "^17.0.4",
+        "react-i18next": "^17.0.6",
         "typescript": "^6.0.3",
         "use-sound": "^5.0.0",
         "use-timer": "^2.0.1"
@@ -4388,9 +4388,9 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.4.tgz",
-      "integrity": "sha512-hQipmK4EF0y6RO6tt6WuqnmWpWYEXmQUUzecmMBuNsIgYd3smXcG4GtYPWhvgxn0pqMOItKlEO8H24HCs5hc3g==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.6.tgz",
+      "integrity": "sha512-WzJ6SMKF+GTD7JZZqxSR1AKKmXjaSu39sClUrNlwxS4Tl7a99O+ltFy6yhPMO+wgZuxpQjJ2PZkfrQKmAqrLhw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "i18next": "^26.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-i18next": "^17.0.4",
+    "react-i18next": "^17.0.6",
     "typescript": "^6.0.3",
     "use-sound": "^5.0.0",
     "use-timer": "^2.0.1"


### PR DESCRIPTION
## 概要
- `react-i18next` を `13.5.0` から `17.0.6` へメジャー更新しました。
- semver範囲外（major）更新のため、このPRは **1依存関係のみ** を扱っています。

## 変更内容
- `package.json` の `react-i18next` を `^17.0.6` へ更新
- `package-lock.json` を更新

## 変更ログ / Breaking Changes の確認
- `react-i18next` 17.0.0 の changelog を確認しました。
- 破壊的変更候補として、`<Trans>` の自動生成キーと `transKeepBasicHtmlNodesFor` 周辺の挙動修正が案内されています。
- このリポジトリ内では `Trans` / `i18nKey` / `transKeepBasicHtmlNodesFor` の利用を確認できず、該当 breaking change の影響は受けにくいと判断しました。
- peer dependency は `i18next >= 26.0.1` で、現状の `i18next 26.x` と整合しています。

## 検証
- `npm test` ✅
- `npm run build` ✅

CI 成功を確認後にマージします。
