### PR TITLE
Dependabot の更新をグルーピング

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,30 @@
 version: 2
+multi-ecosystem-groups:
+  dependency-updates:
+    schedule:
+      interval: "weekly"
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    patterns:
+      - "*"
     cooldown:
       default-days: 2
+    groups:
+      all-npm-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+    multi-ecosystem-group: "dependency-updates"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns:
+      - "*"
+    groups:
+      all-github-actions-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+    multi-ecosystem-group: "dependency-updates"


### PR DESCRIPTION
### Motivation
- Dependabot が作成する複数の依存関係更新 PR を可能な限りまとめてノイズを減らすための設定変更です。
- npm と GitHub Actions の更新を同一のグループで週次に処理することで管理を簡素化します。
- セキュリティ更新についても ecosystem ごとにまとめる意図があります。

### Description
- `.github/dependabot.yml` に `multi-ecosystem-groups` を追加し `dependency-updates` を週次でスケジュールしました。
- `npm` のエントリに `patterns: ["*"]` を追加し既存の `cooldown.default-days: 2` を維持したまま `multi-ecosystem-group: "dependency-updates"` と `all-npm-security-updates` グループを追加しました。
- `github-actions` ecosystem を追加し `patterns: ["*"]` と `all-github-actions-security-updates` グループを設定して同じ `dependency-updates` グループに割り当てました。

### Testing
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/dependabot.yml"); abort("bad version") unless data["version"] == 2; abort("missing multi-ecosystem-groups") unless data["multi-ecosystem-groups"]; abort("missing dependency-updates") unless data.dig("multi-ecosystem-groups", "dependency-updates"); abort("bad updates") unless data["updates"].is_a?(Array) && data["updates"].size == 2; data["updates"].each { |u| abort("missing patterns") unless u["patterns"] == ["*"]; abort("missing multi-ecosystem-group") unless u["multi-ecosystem-group"] == "dependency-updates" }; puts "dependabot.yml is valid YAML"'` を実行して検証し正常終了しました。
- `git diff --check` を実行して差分チェックが問題ないことを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b83669348326a8f78671d465296c)