### PR TITLE
Dependabot設定を更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,30 +1,34 @@
 version: 2
-multi-ecosystem-groups:
-  dependency-updates:
-    schedule:
-      interval: "weekly"
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    patterns:
-      - "*"
     cooldown:
-      default-days: 2
+      default-days: 7
+      semver-major-days: 60
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       all-npm-security-updates:
         applies-to: "security-updates"
         patterns:
           - "*"
-    multi-ecosystem-group: "dependency-updates"
+
   - package-ecosystem: "github-actions"
     directory: "/"
-    patterns:
-      - "*"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       all-github-actions-security-updates:
         applies-to: "security-updates"
         patterns:
           - "*"
-    multi-ecosystem-group: "dependency-updates"


### PR DESCRIPTION
### Motivation
- リポジトリのDependabot設定を参考例に合わせて整理し、依存関係の更新ポリシーを明確化するために更新しました。 
- 通常のminor/patch更新のノイズを減らし、セキュリティ更新を優先的に扱う目的です。 
- `npm` と `github-actions` の両エコシステムを週次でチェックするように統一しました。 

### Description
- `.github/dependabot.yml` を更新し、`npm` の `cooldown` を `default-days: 7` と `semver-major-days: 60` に設定しました. 
- 通常の `version-update:semver-minor` と `version-update:semver-patch` を `ignore` してminor/patchを除外するルールを追加しました. 
- `github-actions` も週次スケジュール化して同様に minor/patch を無視し、各エコシステムのセキュリティ更新をグループ化する設定を追加しました. 

### Testing
- `python` を使った YAML パース検証は `PyYAML` 未導入で失敗しました（環境依存）。 
- `ruby -e 'require "yaml"; ...'` による `.github/dependabot.yml` のパース検証は成功しました。 
- `npm test`（`vitest`）を実行したところテストスイートは成功しました（1 passed）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b21db2438832694a6ac1278207ea1)